### PR TITLE
Refactor argument parsing and update tests

### DIFF
--- a/internal/util/argParser.go
+++ b/internal/util/argParser.go
@@ -5,51 +5,133 @@ import (
 	"strings"
 )
 
-// Checks and parses input parameters of type "--foo=bar" and "--foo 1 1 1 1"
-// returns fixed argument list
-func CleanInputArguments(arguments []string) ([]string, error) {
-	var fixedArguments []string
-	copy(fixedArguments, arguments)
-	for _, argument := range arguments {
-		if strings.HasPrefix(argument, "--") && strings.Contains(argument, "=") {
-			param, value, _ := strings.Cut(argument, "=")
-			// TODO: this misses values consisting of only (more than one) spaces
-			if value != "" && value != " " {
-				fixedArguments = append(fixedArguments, param, value)
-			} else {
-				fixedArguments = append(fixedArguments, param)
-			}
-		} else {
-			fixedArguments = append(fixedArguments, argument)
-		}
-	}
-	//check for missing arguments
-	for index, argument := range fixedArguments[:len(fixedArguments)-1] {
-		if strings.HasPrefix(argument, "--") {
-			if strings.HasPrefix(fixedArguments[index+1], "--") {
-				return nil, fmt.Errorf("parameter '%s' is missing a value", argument)
-			}
-		}
-	}
-	if strings.HasPrefix(fixedArguments[len(fixedArguments)-1], "--") {
-		return nil, fmt.Errorf("parameter '%s' is missing a value", fixedArguments[len(fixedArguments)-1])
-	}
-	return fixedArguments, nil
+type Input struct {
+	parameterHierarchy []string
+	value              string
+	unset              bool
 }
 
-// Takes the input arguments and outputs them as separate values
-// parameterName = "Parent.child1.child2. ... .childn"
-// [parameterName-1 value-1, ...., parameterName-n value-n ] -> [[parent-1, child-1, ...child-n, value1],...]
-func ParseArgs(args []string) [][]string {
-	var splitParameters [][]string
-	argsLength := len(args)
-	for index, parameterNames := range args[1:] {
-		if index%2 != 0 || index+2 == argsLength {
-			continue
-		}
-		parameterAndValue := strings.Split(strings.TrimPrefix(parameterNames, "--"), ".")
-		parameterAndValue = append(parameterAndValue, args[index+2])
-		splitParameters = append(splitParameters, parameterAndValue)
+// Takes the input arguments and outputs them as separate Input structs
+// returns a list of Input structs and an error if the arguments are invalid
+func ParseArgs(args []string) ([]Input, error) {
+	cleanArgs := FormatInputArguments(args)
+
+	err := CheckForMissingValues(cleanArgs)
+	if err != nil {
+		return nil, fmt.Errorf("Input is missing a value: %s", err)
 	}
-	return splitParameters
+	inputList := mapArgsToInput(cleanArgs)
+	return inputList, nil
+}
+
+// Takes the input arguments and outputs them as separate Input structs
+func mapArgsToInput(args []string) []Input {
+	var inputList []Input
+	input := Input{}
+	for _, arg := range args {
+		if isParameter(arg) {
+			input.parameterHierarchy = strings.Split(strings.TrimPrefix(arg, "--"), ".")
+		} else if isParamToUnset(arg) {
+			param := strings.TrimPrefix(arg, "--")
+			param = strings.TrimSuffix(param, "-")
+			input.parameterHierarchy = strings.Split(param, ".")
+			input.unset = true
+			inputList = append(inputList, input)
+			input = Input{}
+		} else {
+			input.value = arg
+			inputList = append(inputList, input)
+			input = Input{}
+		}
+
+	}
+	return inputList
+}
+
+// Parses raw cli input parameters and returns a fixed argument list
+// if a = is used in any form of key=value pair, the = needs to be at least the suffix of the key
+// otherwise it's impossible to differentiate between a key=value pair and a key with a value(starting with =)
+func FormatInputArguments(arguments []string) []string {
+	var fixedArguments []string
+	value := ""
+	for _, argument := range arguments {
+		if isParameterValuePair(argument) {
+			if value != "" {
+				fixedArguments = append(fixedArguments, value)
+				value = ""
+			}
+			param, cutValue, _ := strings.Cut(argument, "=")
+			fixedArguments = append(fixedArguments, param)
+			value = cutValue
+		} else if isParameter(argument) {
+			if value != "" {
+				fixedArguments = append(fixedArguments, value)
+				value = ""
+			}
+
+			fixedArguments = append(fixedArguments, argument)
+		} else {
+			value += argument
+		}
+	}
+	lastElement := arguments[len(arguments)-1]
+	if lastElement == value || isParameterValuePair(lastElement) {
+		fixedArguments = append(fixedArguments, value)
+	}
+	return fixedArguments
+}
+
+// Takes a list of strings and checks if every parameter has a value
+// returns an error if a parameter is missing a value
+func CheckForMissingValues(arguments []string) error {
+	lastIndex := len(arguments) - 1
+	lastArgument := arguments[lastIndex]
+	if isParameter(lastArgument) && !isParamToUnset(lastArgument) {
+		return fmt.Errorf("parameter '%s' is missing a value", lastArgument)
+	} else if isValue(arguments[0]) {
+		return fmt.Errorf("parameter '%s' is missing a value", arguments[0])
+	}
+	var prevArgument string
+	for index, argument := range arguments[1:] {
+		if isValue(argument) {
+			prevArgument = arguments[index]
+			if !isParameter(prevArgument) {
+				return fmt.Errorf("value '%s' is missing a key", prevArgument)
+			}
+		} else if isParamToUnset(argument) {
+			prevArgument = arguments[index]
+			if isParameter(prevArgument) {
+				return fmt.Errorf("parameter '%s' is missing a value", prevArgument)
+			}
+		}
+	}
+
+	return nil
+}
+func isValue(arg string) bool {
+	if !isParamToUnset(arg) && !isParameter(arg) && !isParameterValuePair(arg) {
+		return true
+	}
+	return false
+}
+
+func isParameterValuePair(arg string) bool {
+	if strings.HasPrefix(arg, "--") && strings.Contains(arg, "=") && !isParamToUnset(arg) {
+		return true
+	}
+	return false
+}
+
+func isParameter(arg string) bool {
+	if strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") && !isParamToUnset(arg) {
+		return true
+	}
+	return false
+}
+
+func isParamToUnset(arg string) bool {
+	if strings.HasPrefix(arg, "--") && strings.HasSuffix(arg, "-") {
+		return true
+	}
+	return false
 }

--- a/internal/util/fieldSetter.go
+++ b/internal/util/fieldSetter.go
@@ -10,10 +10,9 @@ import (
 )
 
 // Iterates over all parameters and tries to set them
-func DecorateType(serviceType interface{}, fieldNames [][]string) (interface{}, error) {
-	for _, v := range fieldNames {
-		// TODO: this function "re-parses" arguments again
-		_, err := setParameter(serviceType, v[:len(v)-1], v[len(v)-1])
+func DecorateType(serviceType interface{}, inputs []Input) (interface{}, error) {
+	for _, v := range inputs {
+		_, err := setParameter(serviceType, v.parameterHierarchy, v.value)
 		if err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -72,21 +72,23 @@ func Main(apps applications.AppMap, args []string, out io.Writer) int {
 		return 1
 	}
 
+	var err error
 	service := app.GetDefault()
-	plainArgs, err := util.CleanInputArguments(plainArgs)
-	if err != nil {
-		logrus.Errorf("Invalid arguments: %s", err)
-		return 1
-	}
 
-	parameters := util.ParseArgs(plainArgs)
+	if len(plainArgs) >= 2 {
+		parameters, err := util.ParseArgs(plainArgs[1:])
+		if err != nil {
+			logrus.Errorf("Failed parsing arguments: %s", err)
+			return 1
+		}
 
-	// TODO: Setting an invalid value just ignores it instead of erroring
-	// example: `go run . VSHNPostgreSQL --spec.parameters.backup.retention asdf``
-	_, err = util.DecorateType(service, parameters)
-	if err != nil {
-		logrus.Errorf("failed setting parameters: %s", err)
-		return 1
+		// TODO: Setting an invalid value just ignores it instead of erroring
+		// example: `go run . VSHNPostgreSQL --spec.parameters.backup.retention asdf``
+		_, err = util.DecorateType(service, parameters)
+		if err != nil {
+			logrus.Errorf("failed setting parameters: %s", err)
+			return 1
+		}
 	}
 
 	err = writeYAML(service, out)

--- a/tests/golden/exoOpenSearch.json
+++ b/tests/golden/exoOpenSearch.json
@@ -1,4 +1,4 @@
 {
     "default": "ExoscaleOpenSearch",
-    "parameters": "ExoscaleOpenSearch --spec.parameters.backup.timeOfDay=24:00:00 spec.parameters.size.plan enterprise-large --spec.parameters.service.majorVersion 9999"
+    "parameters": "ExoscaleOpenSearch --spec.parameters.backup.timeOfDay=24:00:00 --spec.parameters.size.plan enterprise-large --spec.parameters.service.majorVersion 9999"
 }


### PR DESCRIPTION
Refactor argument parsing to use struct instead of slices.
Add logic to correctly parse arguments to unset a parameter  ex. `--spec.parameters.size.CPU-`
resolves APPX-62