### PR TITLE
Ensure WriteConnectionSecretToRef is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,9 +86,11 @@ func Main(apps applications.AppMap, args []string, out io.Writer) int {
 		printUsage(args[0], apps)
 		return 1
 	}
-	////appcat-cli serviceKind
+
 	service := app.GetDefault()
 	parameters = append(parameters, util.Input{ParameterHierarchy: []string{"ObjectMeta", "Name"}, Value: resourceName, Unset: false})
+	parameters = append([]util.Input{{ParameterHierarchy: []string{"Spec", "WriteConnectionSecretToRef", "Name"}, Value: resourceName + "-creds", Unset: false}}, parameters...)
+
 	_, err = util.DecorateType(service, parameters)
 	if err != nil {
 		logrus.Errorf("failed setting parameters: %s", err)

--- a/tests/golden/exoKafka.json
+++ b/tests/golden/exoKafka.json
@@ -1,6 +1,7 @@
 {
     "default": "kafka-default --kind ExoscaleKafka",
     "parameters": "kafka-parameters --kind ExoscaleKafka --spec.parameters.maintenance.dayOfWeek=monday --spec.parameters.service.zone ch-fr-1 --spec.parameters.size.plan enterprise-large",
+    "secret-ref": "kafka-secret-ref --kind ExoscaleKafka --spec.writeconnectionsecrettoref.name new-cred",
     "unset": "kafka-unset --kind ExoscaleKafka --spec.parameters.maintenance.dayOfWeek- --spec.parameters.service- --spec.parameters.size.plan-",
     "jsonInput": "kafka-jsonInput --kind ExoscaleKafka --spec.parameters.maintenance={\"DayOfWeek\":\"monday\",\"TimeOfDay\":\"00:00:00\"} --spec.parameters.service {\"Zone\":\"ch-fr-99\"} --spec.parameters.size.plan {\"Foo\":\"Bar\"}"
 }

--- a/tests/golden/exoKafka/default.yaml
+++ b/tests/golden/exoKafka/default.yaml
@@ -15,5 +15,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: startup-2
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: kafka-default-creds
 status: {}

--- a/tests/golden/exoKafka/jsonInput.yaml
+++ b/tests/golden/exoKafka/jsonInput.yaml
@@ -14,5 +14,6 @@ spec:
       zone: ch-fr-99
     size:
       plan: '{"Foo":"Bar"}'
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: kafka-jsonInput-creds
 status: {}

--- a/tests/golden/exoKafka/parameters.yaml
+++ b/tests/golden/exoKafka/parameters.yaml
@@ -15,5 +15,6 @@ spec:
       zone: ch-fr-1
     size:
       plan: enterprise-large
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: kafka-parameters-creds
 status: {}

--- a/tests/golden/exoKafka/secret-ref.yaml
+++ b/tests/golden/exoKafka/secret-ref.yaml
@@ -1,22 +1,20 @@
 apiVersion: exoscale.appcat.vshn.io/v1
-kind: ExoscalePostgreSQL
+kind: ExoscaleKafka
 metadata:
   creationTimestamp: null
-  name: postgres-parameters
+  name: kafka-secret-ref
 spec:
   parameters:
-    backup:
-      timeOfDay: "24:00:00"
     maintenance:
       dayOfWeek: sunday
       timeOfDay: "00:00:00"
     network: {}
     service:
-      majorVersion: "13"
-      pgSettings: null
+      kafkaSettings: null
+      version: 3.4.0
       zone: ch-dk-2
     size:
-      plan: enterprise-large
+      plan: startup-2
   writeConnectionSecretToRef:
-    name: postgres-parameters-creds
+    name: new-cred
 status: {}

--- a/tests/golden/exoKafka/unset.yaml
+++ b/tests/golden/exoKafka/unset.yaml
@@ -11,5 +11,6 @@ spec:
     service:
       kafkaSettings: null
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: kafka-unset-creds
 status: {}

--- a/tests/golden/exoMySQL.json
+++ b/tests/golden/exoMySQL.json
@@ -1,6 +1,7 @@
 {
     "default": "mysql-default --kind ExoscaleMySQL",
     "parameters": "mysql-parameters --kind ExoscaleMySQL --spec.parameters.backup.timeOfDay=24:00:00 --spec.parameters.maintenance.dayOfWeek monday --spec.parameters.service.majorVersion 9999",
+    "secret-ref": "mysql-secret-ref --kind ExoscaleMySQL --spec.writeconnectionsecrettoref.name new-cred",
     "unset": "mysql-unset --kind ExoscaleMySQL --spec.parameters.maintenance.dayOfWeek- --spec.parameters.service- --spec.parameters.size.plan-",
     "jsonInput": "mysql-jsonInput --kind ExoscaleMySQL --spec.parameters.maintenance={\"DayOfWeek\":\"monday\",\"TimeOfDay\":\"00:00:00\"} --spec.parameters.service {\"Zone\":\"ch-fr-99\"} --spec.parameters.size.plan {\"Foo\":\"Bar\"}"
 }

--- a/tests/golden/exoMySQL/default.yaml
+++ b/tests/golden/exoMySQL/default.yaml
@@ -17,5 +17,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: hobbyist-2
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: mysql-default-creds
 status: {}

--- a/tests/golden/exoMySQL/jsonInput.yaml
+++ b/tests/golden/exoMySQL/jsonInput.yaml
@@ -16,5 +16,6 @@ spec:
       zone: ch-fr-99
     size:
       plan: '{"Foo":"Bar"}'
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: mysql-jsonInput-creds
 status: {}

--- a/tests/golden/exoMySQL/parameters.yaml
+++ b/tests/golden/exoMySQL/parameters.yaml
@@ -17,5 +17,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: hobbyist-2
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: mysql-parameters-creds
 status: {}

--- a/tests/golden/exoMySQL/secret-ref.yaml
+++ b/tests/golden/exoMySQL/secret-ref.yaml
@@ -1,22 +1,22 @@
 apiVersion: exoscale.appcat.vshn.io/v1
-kind: ExoscalePostgreSQL
+kind: ExoscaleMySQL
 metadata:
   creationTimestamp: null
-  name: postgres-parameters
+  name: mysql-secret-ref
 spec:
   parameters:
     backup:
-      timeOfDay: "24:00:00"
+      timeOfDay: "12:00:00"
     maintenance:
       dayOfWeek: sunday
       timeOfDay: "00:00:00"
     network: {}
     service:
-      majorVersion: "13"
-      pgSettings: null
+      majorVersion: "8"
+      mysqlSettings: null
       zone: ch-dk-2
     size:
-      plan: enterprise-large
+      plan: hobbyist-2
   writeConnectionSecretToRef:
-    name: postgres-parameters-creds
+    name: new-cred
 status: {}

--- a/tests/golden/exoMySQL/unset.yaml
+++ b/tests/golden/exoMySQL/unset.yaml
@@ -13,5 +13,6 @@ spec:
     service:
       mysqlSettings: null
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: mysql-unset-creds
 status: {}

--- a/tests/golden/exoOpenSearch.json
+++ b/tests/golden/exoOpenSearch.json
@@ -1,5 +1,6 @@
 {
     "default": "opensearch-default --kind ExoscaleOpenSearch",
+    "secret-ref": "opensearch-secret-ref --kind ExoscaleOpenSearch --spec.writeconnectionsecrettoref.name new-cred",
     "parameters": "opensearch-parameters --kind ExoscaleOpenSearch --spec.parameters.backup.timeOfDay=24:00:00 --spec.parameters.size.plan enterprise-large --spec.parameters.service.majorVersion 9999",
     "unset": "opensearch-unset --kind ExoscaleOpenSearch --spec.parameters.maintenance.dayOfWeek- --spec.parameters.service- --spec.parameters.size.plan-",
     "jsonInput": "opensearch-jsonInput --kind ExoscaleOpenSearch --spec.parameters.maintenance={\"DayOfWeek\":\"monday\",\"TimeOfDay\":\"00:00:00\"} --spec.parameters.service {\"Zone\":\"ch-fr-99\"} --spec.parameters.size.plan {\"Foo\":\"Bar\"}"

--- a/tests/golden/exoOpenSearch/default.yaml
+++ b/tests/golden/exoOpenSearch/default.yaml
@@ -17,5 +17,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: hobbyist-2
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: opensearch-default-creds
 status: {}

--- a/tests/golden/exoOpenSearch/jsonInput.yaml
+++ b/tests/golden/exoOpenSearch/jsonInput.yaml
@@ -16,5 +16,6 @@ spec:
       zone: ch-fr-99
     size:
       plan: '{"Foo":"Bar"}'
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: opensearch-jsonInput-creds
 status: {}

--- a/tests/golden/exoOpenSearch/parameters.yaml
+++ b/tests/golden/exoOpenSearch/parameters.yaml
@@ -17,5 +17,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: enterprise-large
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: opensearch-parameters-creds
 status: {}

--- a/tests/golden/exoOpenSearch/secret-ref.yaml
+++ b/tests/golden/exoOpenSearch/secret-ref.yaml
@@ -1,22 +1,22 @@
 apiVersion: exoscale.appcat.vshn.io/v1
-kind: ExoscalePostgreSQL
+kind: ExoscaleOpenSearch
 metadata:
   creationTimestamp: null
-  name: postgres-parameters
+  name: opensearch-secret-ref
 spec:
   parameters:
     backup:
-      timeOfDay: "24:00:00"
+      timeOfDay: "12:00:00"
     maintenance:
       dayOfWeek: sunday
       timeOfDay: "00:00:00"
     network: {}
     service:
-      majorVersion: "13"
-      pgSettings: null
+      majorVersion: "2"
+      opensearchSettings: null
       zone: ch-dk-2
     size:
-      plan: enterprise-large
+      plan: hobbyist-2
   writeConnectionSecretToRef:
-    name: postgres-parameters-creds
+    name: new-cred
 status: {}

--- a/tests/golden/exoOpenSearch/unset.yaml
+++ b/tests/golden/exoOpenSearch/unset.yaml
@@ -13,5 +13,6 @@ spec:
     service:
       opensearchSettings: null
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: opensearch-unset-creds
 status: {}

--- a/tests/golden/exoPostgreSQL.json
+++ b/tests/golden/exoPostgreSQL.json
@@ -1,5 +1,6 @@
 {
     "default": "postgres-default --kind ExoscalePostgreSQL",
+    "secret-ref": "postgres-secret-ref --kind ExoscalePostgreSQL --spec.writeconnectionsecrettoref.name new-cred",
     "parameters": "postgres-parameters --kind ExoscalePostgreSQL --spec.parameters.backup.timeOfDay=24:00:00 --spec.parameters.service.majorVersion 13 --spec.parameters.size.plan enterprise-large",
     "unset": "postgres-unset --kind ExoscalePostgreSQL --spec.parameters.maintenance.dayOfWeek- --spec.parameters.service- --spec.parameters.size.plan-",
     "jsonInput": "postgres-jsonInput --kind ExoscalePostgreSQL --spec.parameters.maintenance={\"DayOfWeek\":\"monday\",\"TimeOfDay\":\"00:00:00\"} --spec.parameters.service {\"Zone\":\"ch-fr-99\"} --spec.parameters.size.plan {\"Foo\":\"Bar\"}"

--- a/tests/golden/exoPostgreSQL/default.yaml
+++ b/tests/golden/exoPostgreSQL/default.yaml
@@ -17,5 +17,6 @@ spec:
       zone: ch-dk-2
     size:
       plan: hobbyist-2
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-default-creds
 status: {}

--- a/tests/golden/exoPostgreSQL/jsonInput.yaml
+++ b/tests/golden/exoPostgreSQL/jsonInput.yaml
@@ -16,5 +16,6 @@ spec:
       zone: ch-fr-99
     size:
       plan: '{"Foo":"Bar"}'
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-jsonInput-creds
 status: {}

--- a/tests/golden/exoPostgreSQL/secret-ref.yaml
+++ b/tests/golden/exoPostgreSQL/secret-ref.yaml
@@ -2,21 +2,21 @@ apiVersion: exoscale.appcat.vshn.io/v1
 kind: ExoscalePostgreSQL
 metadata:
   creationTimestamp: null
-  name: postgres-parameters
+  name: postgres-secret-ref
 spec:
   parameters:
     backup:
-      timeOfDay: "24:00:00"
+      timeOfDay: "12:00:00"
     maintenance:
       dayOfWeek: sunday
       timeOfDay: "00:00:00"
     network: {}
     service:
-      majorVersion: "13"
+      majorVersion: "15"
       pgSettings: null
       zone: ch-dk-2
     size:
-      plan: enterprise-large
+      plan: hobbyist-2
   writeConnectionSecretToRef:
-    name: postgres-parameters-creds
+    name: new-cred
 status: {}

--- a/tests/golden/exoPostgreSQL/unset.yaml
+++ b/tests/golden/exoPostgreSQL/unset.yaml
@@ -13,5 +13,6 @@ spec:
     service:
       pgSettings: null
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-unset-creds
 status: {}

--- a/tests/golden/exoRedis.json
+++ b/tests/golden/exoRedis.json
@@ -1,5 +1,6 @@
 {
     "default": "redis-default --kind ExoscaleRedis",
+    "secret-ref": "redis-secret-ref --kind ExoscaleRedis --spec.writeconnectionsecrettoref.name new-cred",
     "parameters": "redis-parameters --kind ExoscaleRedis --spec.parameters.size.plan=enterprise-large --spec.parameters.service.zone ch-fr-1 --spec.parameters.maintenance.timeOfDay 24:00:00",
     "unset": "redis-unset --kind ExoscaleRedis --spec.parameters.maintenance.dayOfWeek- --spec.parameters.service- --spec.parameters.service.redisSettings-",
     "jsonInput": "redis-jsonInput --kind ExoscaleRedis --spec.parameters.maintenance={\"DayOfWeek\":\"monday\",\"TimeOfDay\":\"00:00:00\"} --spec.parameters.service {\"Zone\":\"ch-fr-99\"} --spec.parameters.size.plan {\"Foo\":\"Bar\"}"

--- a/tests/golden/exoRedis/default.yaml
+++ b/tests/golden/exoRedis/default.yaml
@@ -13,5 +13,6 @@ spec:
       redisSettings: null
       zone: ch-dk-2
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-default-creds
 status: {}

--- a/tests/golden/exoRedis/jsonInput.yaml
+++ b/tests/golden/exoRedis/jsonInput.yaml
@@ -14,5 +14,6 @@ spec:
       zone: ch-fr-99
     size:
       plan: '{"Foo":"Bar"}'
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-jsonInput-creds
 status: {}

--- a/tests/golden/exoRedis/parameters.yaml
+++ b/tests/golden/exoRedis/parameters.yaml
@@ -14,5 +14,6 @@ spec:
       zone: ch-fr-1
     size:
       plan: enterprise-large
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-parameters-creds
 status: {}

--- a/tests/golden/exoRedis/secret-ref.yaml
+++ b/tests/golden/exoRedis/secret-ref.yaml
@@ -1,22 +1,18 @@
 apiVersion: exoscale.appcat.vshn.io/v1
-kind: ExoscalePostgreSQL
+kind: ExoscaleRedis
 metadata:
   creationTimestamp: null
-  name: postgres-parameters
+  name: redis-secret-ref
 spec:
   parameters:
-    backup:
-      timeOfDay: "24:00:00"
     maintenance:
       dayOfWeek: sunday
       timeOfDay: "00:00:00"
     network: {}
     service:
-      majorVersion: "13"
-      pgSettings: null
+      redisSettings: null
       zone: ch-dk-2
-    size:
-      plan: enterprise-large
+    size: {}
   writeConnectionSecretToRef:
-    name: postgres-parameters-creds
+    name: new-cred
 status: {}

--- a/tests/golden/exoRedis/unset.yaml
+++ b/tests/golden/exoRedis/unset.yaml
@@ -11,5 +11,6 @@ spec:
     service:
       redisSettings: null
     size: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-unset-creds
 status: {}

--- a/tests/golden/vshnPostgreSQL.json
+++ b/tests/golden/vshnPostgreSQL.json
@@ -1,5 +1,6 @@
 {
     "default": "postgres-default --kind VSHNPostgreSQL",
+    "secret-ref": "postgres-secret-ref --kind VSHNPostgreSQL --spec.writeconnectionsecrettoref.name new-cred",
     "parameters": "postgres-parameters --kind VSHNPostgreSQL --spec.parameters.backup.retention=9999 --spec.parameters.backup.schedule \"1 1 1 1 1\" --spec.parameters.size.CPU 100000m",
     "unset": "postgres-unset --kind VSHNPostgreSQL --spec.parameters.size.disk- --spec.parameters.service- --spec.parameters.scheduling.nodeSelector-",
     "jsonInput": "postgres-jsonInput --kind VSHNPostgreSQL --spec.parameters.size={\"cpu\":\"99999m\",\"Memory\":\"9999Gi\",\"disk\":\"9999Gi\",\"Requests\":{\"Memory\":\"9999Gi\"}} --spec.parameters.scheduling.nodeSelector {\"appuio.io/node-class\":\"testing\"} --spec.parameters.backup.schedule {\"Foo\":\"Bar\"}"

--- a/tests/golden/vshnPostgreSQL/default.yaml
+++ b/tests/golden/vshnPostgreSQL/default.yaml
@@ -24,5 +24,6 @@ spec:
       requests:
         cpu: 300m
         memory: 1000Mi
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-default-creds
 status: {}

--- a/tests/golden/vshnPostgreSQL/parameters.yaml
+++ b/tests/golden/vshnPostgreSQL/parameters.yaml
@@ -24,5 +24,6 @@ spec:
       requests:
         cpu: 300m
         memory: 1000Mi
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-parameters-creds
 status: {}

--- a/tests/golden/vshnPostgreSQL/secret-ref.yaml
+++ b/tests/golden/vshnPostgreSQL/secret-ref.yaml
@@ -2,27 +2,28 @@ apiVersion: vshn.appcat.vshn.io/v1
 kind: VSHNPostgreSQL
 metadata:
   creationTimestamp: null
-  name: postgres-jsonInput
+  name: postgres-secret-ref
 spec:
   parameters:
     backup:
       retention: 12
-      schedule: '{"Foo":"Bar"}'
+      schedule: 30 23 * * *
     maintenance: {}
     network: {}
     restore: {}
     scheduling:
       nodeSelector:
-        appuio.io/node-class: testing
+        appuio.io/node-class: plus
     service:
       majorVersion: "15"
       pgSettings: null
     size:
-      cpu: 99999m
-      disk: 9999Gi
-      memory: 9999Gi
+      cpu: 600m
+      disk: 80Gi
+      memory: 3500Mi
       requests:
-        memory: 9999Gi
+        cpu: 300m
+        memory: 1000Mi
   writeConnectionSecretToRef:
-    name: postgres-jsonInput-creds
+    name: new-cred
 status: {}

--- a/tests/golden/vshnPostgreSQL/unset.yaml
+++ b/tests/golden/vshnPostgreSQL/unset.yaml
@@ -20,5 +20,6 @@ spec:
       requests:
         cpu: 300m
         memory: 1000Mi
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: postgres-unset-creds
 status: {}

--- a/tests/golden/vshnRedis.json
+++ b/tests/golden/vshnRedis.json
@@ -1,5 +1,6 @@
 {
     "default": "redis-default --kind VSHNRedis",
+    "secret-ref": "redis-secret-ref --kind VSHNRedis --spec.writeconnectionsecrettoref.name new-cred",
     "parameters": "redis-parameters --kind VSHNRedis --spec.writeConnectionSecretToRef.Name=redisSecret --spec.parameters.tls.tlsauthClients false --spec.parameters.tls.tlsenabled false --spec.parameters.service.version 9999",
     "unset": "redis-unset --kind VSHNRedis --spec.parameters.size.disk- --spec.parameters.tls- --spec.parameters.service.redisSettings-",
     "jsonInput": "redis-jsonInput --kind VSHNRedis --spec.parameters.size={\"cpuLimits\":\"99999m\",\"memoryLimits\":\"9999Gi\"} --spec.parameters.service {\"redisSettings\":\"| activedefrag no\"} --spec.parameters.service.version {\"Foo\":\"Bar\"}"

--- a/tests/golden/vshnRedis/default.yaml
+++ b/tests/golden/vshnRedis/default.yaml
@@ -18,5 +18,6 @@ spec:
     tls:
       authClients: true
       enabled: true
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-default-creds
 status: {}

--- a/tests/golden/vshnRedis/secret-ref.yaml
+++ b/tests/golden/vshnRedis/secret-ref.yaml
@@ -2,19 +2,22 @@ apiVersion: vshn.appcat.vshn.io/v1
 kind: VSHNRedis
 metadata:
   creationTimestamp: null
-  name: redis-jsonInput
+  name: redis-secret-ref
 spec:
   parameters:
     scheduling: {}
     service:
-      redisSettings: '| activedefrag no'
-      version: '{"Foo":"Bar"}'
+      redisSettings: '|activedefrag yes'
+      version: "7.0"
     size:
-      cpuLimits: 99999m
-      memoryLimits: 9999Gi
+      cpuLimits: 1000m
+      cpuRequests: 500m
+      disk: 80Gi
+      memoryLimits: 1Gi
+      memoryRequests: 500Mi
     tls:
       authClients: true
       enabled: true
   writeConnectionSecretToRef:
-    name: redis-jsonInput-creds
+    name: new-cred
 status: {}

--- a/tests/golden/vshnRedis/unset.yaml
+++ b/tests/golden/vshnRedis/unset.yaml
@@ -14,5 +14,6 @@ spec:
       memoryLimits: 1Gi
       memoryRequests: 500Mi
     tls: {}
-  writeConnectionSecretToRef: {}
+  writeConnectionSecretToRef:
+    name: redis-unset-creds
 status: {}


### PR DESCRIPTION
Resolves APPX-88
Changes:
- Spec.WriteConnectionSecretToRef.Name gets default Value of ServiceName+"-creds", get overwritten if set manually
- Adds test cases for above changes
- Fixes invalid field values in defaults and tests