### PR TITLE
Change: info level log to stderr

### DIFF
--- a/internal/util/fieldSetter.go
+++ b/internal/util/fieldSetter.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -64,6 +65,7 @@ func setParameter(serviceType interface{}, input Input) (interface{}, error) {
 		return nil, err
 	}
 	info := fmt.Sprintf("setting field: %s value: %s", strings.Join(input.ParameterHierarchy, HIERARCHY_DELIMITER), input.Value)
+	logrus.SetOutput(os.Stderr)
 	logrus.Info(info)
 
 	return serviceType, nil


### PR DESCRIPTION
Configure logrus to write info level logs to stderr instead of stdout.
Is required because k8ify reads from stdout.